### PR TITLE
Fix "hidden space" regex patterns in loadBank method

### DIFF
--- a/qtiConverterApp.py
+++ b/qtiConverterApp.py
@@ -1389,11 +1389,11 @@ class makeQti():
             with self.ifile.open(mode = 'r', encoding = "utf-8-sig") as f:
                 data=f.read()
             # get rid of hidden spaces on new lines
-            data = re.sub('\ +\n', '\n', data.strip(), flags=re.MULTILINE)
+            data = re.sub(r'\ +\n', '\n', data.strip(), flags=re.MULTILINE)
             # get rid of hidden tabs before new lines
             data = re.sub('\t+\n', '\n', data.strip(), flags=re.MULTILINE)
             # get rid of hidden spaces and tabsbefore lines
-            data = re.sub('^[\ \t]+', '', data.strip(), flags=re.MULTILINE)
+            data = re.sub(r'^[\ \t]+', '', data.strip(), flags=re.MULTILINE)
             # get rid of lines that begin with # as a comment indicator
             data = re.sub('^#.*$', '', data.strip(), flags=re.MULTILINE)
             # combine multiple new lines into just the needed two


### PR DESCRIPTION
In the current version, I get `SyntaxWarning` when I execute the `qtiConverterApp` file:

```
qtiConverterApp.py:890: SyntaxWarning: invalid escape sequence '\ '
  data = re.sub("\ +\n", "\n", data.strip(), flags=re.MULTILINE)
qtiConverterApp.py:894: SyntaxWarning: invalid escape sequence '\ '
  data = re.sub("^[\ \t]+", "", data.strip(), flags=re.MULTILINE)
```

This change attempts to fix that issue.